### PR TITLE
Add .NET Standard 2.0 support

### DIFF
--- a/EasyPost.Scotch.Tests/EasyPost.Scotch.Tests.csproj
+++ b/EasyPost.Scotch.Tests/EasyPost.Scotch.Tests.csproj
@@ -2,7 +2,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>latestMajor</LangVersion>
         <ApplicationIcon />
         <OutputType>Library</OutputType>

--- a/EasyPost.Scotch/EasyPost.Scotch.csproj
+++ b/EasyPost.Scotch/EasyPost.Scotch.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>latestMajor</LangVersion>
         <RootNamespace>EasyPost.Scotch</RootNamespace>
     </PropertyGroup>


### PR DESCRIPTION
- Scotch now supports .NET Standard 2.0, .NET Core 3.1, .NET 5.0 and NET 6.0
- Scotch tests run in (check compatibility with) .NET Framework 4.6.1 (for .NET Standard 2.0 version), .NET Core 3.1, .NET 5.0 and .NET 6.0